### PR TITLE
Eliminate ambiguity in the "drawn" date.

### DIFF
--- a/graphs1090.sh
+++ b/graphs1090.sh
@@ -870,7 +870,7 @@ dump1090_hub_graphs() {
 
 period="$1"
 step="$2"
-nowlit=`date '+%m/%d/%y %H:%M %Z'`;
+nowlit=`date '+%Y-%m-%d %H:%M %Z'`;
 
 # Changing the following two variables means you need to change the names in html/graph.js as well so that the graphs are correctly displayed
 dump1090_instance="localhost"


### PR DESCRIPTION
MM/DD/YYYY date format that is currently used creates ambiguity for dates like 1/12/2018 and can be be misread by more than half world population as DD/MM/YYYY

Use YYYY-MM-DD date format instead