### PR TITLE
Place Dump978 Graphs Before System Graphs

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -95,6 +95,36 @@
 					</div>
 				</div>
 			</div>
+			<!-- Dump978 Graphs -->
+			<div id="panel_978" class="panel panel-default" style="display:none"> <!-- dump978 -->
+				<div class="panel-heading">Dump978 Graphs</div>
+				<div class="panel-body">
+					<div class="row">
+						<div class="column text-center">
+							<a id ="dump1090-messages_978-link" href="#">
+								<img id="dump1090-messages_978-image" class="img-responsive" src="#" alt="UAT Message Rate">
+							</a>
+						</div>
+						<div class="column text-center">
+							<a id ="dump1090-aircraft_978-link" href="#">
+								<img id="dump1090-aircraft_978-image" class="img-responsive" src="#" alt="UAT Aircraft">
+							</a>
+						</div>
+					</div>
+					<div class="row">
+						<div class="column text-center">
+							<a id ="dump1090-range_978-link" href="#">
+								<img id="dump1090-range_978-image" class="img-responsive" src="#" alt="UAT Max Range">
+							</a>
+						</div>
+						<div class="column text-center">
+							<a id ="dump1090-signal_978-link" href="#">
+								<img id="dump1090-signal_978-image" class="img-responsive" src="#" alt="UAT Signal Level">
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
 			<!-- System Graphs -->
 			<div class="panel panel-default">
 				<div class="panel-heading">System Graphs</div>
@@ -144,36 +174,6 @@
 						<div class="column text-center">
 							<a id ="system-disk_io_octets-link" href="#">
 								<img id="system-disk_io_octets-image" class="img-responsive" src="#" alt="Disk I/O - Bandwidth">
-							</a>
-						</div>
-					</div>
-				</div>
-			</div>
-			<!-- Dump978 Graphs -->
-			<div id="panel_978" class="panel panel-default" style="display:none"> <!-- dump978 -->
-				<div class="panel-heading">Dump978 Graphs</div>
-				<div class="panel-body">
-					<div class="row">
-						<div class="column text-center">
-							<a id ="dump1090-messages_978-link" href="#">
-								<img id="dump1090-messages_978-image" class="img-responsive" src="#" alt="UAT Message Rate">
-							</a>
-						</div>
-						<div class="column text-center">
-							<a id ="dump1090-aircraft_978-link" href="#">
-								<img id="dump1090-aircraft_978-image" class="img-responsive" src="#" alt="UAT Aircraft">
-							</a>
-						</div>
-					</div>
-					<div class="row">
-						<div class="column text-center">
-							<a id ="dump1090-range_978-link" href="#">
-								<img id="dump1090-range_978-image" class="img-responsive" src="#" alt="UAT Max Range">
-							</a>
-						</div>
-						<div class="column text-center">
-							<a id ="dump1090-signal_978-link" href="#">
-								<img id="dump1090-signal_978-image" class="img-responsive" src="#" alt="UAT Signal Level">
 							</a>
 						</div>
 					</div>


### PR DESCRIPTION
It's cleaner to place Dump978 graphs before the system graphs when they are not hidden:

![image](https://user-images.githubusercontent.com/5298134/111572015-359c5900-877e-11eb-935c-742218612e85.png)
