### PR TITLE
Handle non number values at file creation

### DIFF
--- a/scatter.sh
+++ b/scatter.sh
@@ -49,6 +49,10 @@ join -o 1.1 1.2 2.2 ${tmp}/range ${tmp}/messages_l > ${tmp}/tmp
 join -o 1.1 1.2 1.3 2.2 ${tmp}/tmp ${tmp}/messages_r > ${tmp}/tmp1
 join -o 1.2 1.3 1.4 2.2 ${tmp}/tmp1 ${tmp}/aircraft > $data_dir/$date
 
+# get rid of nan values to simplify usage in gnuplot
+
+sed -i 's/nan/0/g' $data_dir/$date
+
 # some cleanup
 rm -f $(find $data_dir -type f | sort | head -n-450)
 rm -rf "${tmp}"


### PR DESCRIPTION
The data stored for local messages differs between readsb and dump1090-fa when an external receiver such as airspy is used. dump1090-fa records message rates in dump1090_messages-local_accepted.rrd as numeric 0, whereas with readsb it is stored as nan. This is problematic for gnuplot which ignores lines with nan fields completely. Changing it here keeps the data consistent whether dump1090 or readsb are used.