### PR TITLE
Fix usage of sed options in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -178,7 +178,7 @@ do
     # only add interface starting with et en and wl
     case $iface in
         et*|en*|wl*)
-sed -ie '/<Plugin "interface">/{a\
+sed -i -e '/<Plugin "interface">/{a\
     Interface "'$iface'"
 }' /etc/collectd/collectd.conf
         ;;


### PR DESCRIPTION
When adding interfaces to collectd.conf, the sed options
need to be `-i -e` instead of `-ie` otherwise an orphaned
collectd.confe file is created.

Resolves: #84
