### PR TITLE
Fix: Whole script would fail if any package could not be found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -109,12 +109,11 @@ else
         && ! dpkg -s libpython3.13 2>/dev/null | grep 'Status.*installed' &>/dev/null
 	then
         aptUpdate
-
-		apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.9'
-		apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.10'
-		apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.11'
-		apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.12'
-		apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.13'
+		   apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.9'  \
+		|| apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.10' \
+		|| apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.11' \
+		|| apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.12' \
+		|| apt-get install --no-install-suggests --no-install-recommends -y 'libpython3.13'
 	fi
 fi
 


### PR DESCRIPTION

Fix bug introduced in  by b5fff288d33e49abaa009b45e63fbd6db34a695e whereby the whole script would fail if any package could not be found (e.g. libpython3.9).