### PR TITLE
add apple-touch-icon link to index.html for better mobile support

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -7,6 +7,7 @@
 		<link rel="stylesheet" href="bootstrap.custom.light.css">
 		<link rel="stylesheet" href="portal.css">
 		<link rel="icon" type="image/png" href="graphs-favicon.png">
+		<link rel="apple-touch-icon" href="apple-touch-icon.png">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-status-bar-style" content="white">
         <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Wired up the apple icon so it is referenced properly by mobile devices, otherwise in certain use cases they would fallback and look for an icon that does not exist.